### PR TITLE
WIP: Fix range proofs

### DIFF
--- a/tests/primitives/test_rangeproof.py
+++ b/tests/primitives/test_rangeproof.py
@@ -7,6 +7,7 @@ TODO: Add tests for failure conditions of PowerTwoRangeStmt
 import pytest
 
 from petlib.bn import Bn
+from petlib.ec import EcGroup
 
 from zksk import Secret
 from zksk.pairings import BilinearGroupPair
@@ -98,4 +99,19 @@ def test_range_stmt_non_interactive_outside_range(group):
 
     with pytest.raises(Exception):
         tr = stmt.prove()
+
+def test_range_proof_outside():
+    group = EcGroup()
+    x = Secret(value=15)
+    randomizer = Secret(value=group.order().random())
+
+    g, h = make_generators(2, group)
+    lo = 0
+    hi = 14
+
+    com = x * g + randomizer * h
+    stmt = RangeStmt(com.eval(), g, h, lo, hi, x, randomizer)
+    nizk = stmt.prove()
+    # x is outside [lo, hi]. Verification should fail
+    assert stmt.verify(nizk) is False
 

--- a/tests/primitives/test_rangeproof.py
+++ b/tests/primitives/test_rangeproof.py
@@ -58,6 +58,7 @@ def test_power_two_range_stmt_interactive():
     assert protocol.verify()
     verifier.stmt.full_validate()
 
+
 def test_range_stmt_non_interactive_start_at_zero(group):
     x = Secret(value=3)
     randomizer = Secret(value=group.order().random())
@@ -71,6 +72,7 @@ def test_range_stmt_non_interactive_start_at_zero(group):
 
     tr = stmt.prove()
     assert stmt.verify(tr)
+
 
 def test_range_stmt_non_interactive_start_at_nonzero(group):
     x = Secret(value=14)
@@ -86,6 +88,7 @@ def test_range_stmt_non_interactive_start_at_nonzero(group):
     tr = stmt.prove()
     assert stmt.verify(tr)
 
+
 def test_range_stmt_non_interactive_outside_range(group):
     x = Secret(value=15)
     randomizer = Secret(value=group.order().random())
@@ -99,6 +102,7 @@ def test_range_stmt_non_interactive_outside_range(group):
 
     with pytest.raises(Exception):
         tr = stmt.prove()
+
 
 def test_range_proof_outside():
     group = EcGroup()
@@ -134,4 +138,3 @@ def test_range_proof_outside_range_below():
     with pytest.raises(Exception):
         nizk = stmt.prove()
         stmt.verify(nizk)
-

--- a/tests/primitives/test_rangeproof.py
+++ b/tests/primitives/test_rangeproof.py
@@ -11,7 +11,7 @@ from petlib.ec import EcGroup
 
 from zksk import Secret
 from zksk.pairings import BilinearGroupPair
-from zksk.primitives.rangeproof import PowerTwoRangeStmt, RangeStmt
+from zksk.primitives.rangeproof import PowerTwoRangeStmt, RangeStmt, RangeOnlyStmt
 from zksk.utils import make_generators
 from zksk.utils.debug import SigmaProtocol
 
@@ -111,7 +111,27 @@ def test_range_proof_outside():
 
     com = x * g + randomizer * h
     stmt = RangeStmt(com.eval(), g, h, lo, hi, x, randomizer)
-    nizk = stmt.prove()
-    # x is outside [lo, hi]. Verification should fail
-    assert stmt.verify(nizk) is False
+    with pytest.raises(Exception):
+        nizk = stmt.prove()
+        stmt.verify(nizk)
+
+
+def test_range_proof_outside_range_above():
+    x = Secret(value=7)
+    lo = 0
+    hi = 6
+    stmt = RangeOnlyStmt(lo, hi, x)
+    with pytest.raises(Exception):
+        nizk = stmt.prove()
+        assert stmt.verify(nizk) == False
+
+
+def test_range_proof_outside_range_below():
+    x = Secret(value=1)
+    lo = 2
+    hi = 7
+    stmt = RangeOnlyStmt(lo, hi, x)
+    with pytest.raises(Exception):
+        nizk = stmt.prove()
+        stmt.verify(nizk)
 

--- a/zksk/primitives/rangeproof.py
+++ b/zksk/primitives/rangeproof.py
@@ -1,5 +1,5 @@
 r"""
-"Range proof": ZK proof that a committed value lies within a range.
+Range proof: ZK proof that a committed value lies within a range.
 
 .. math::
 
@@ -142,15 +142,13 @@ class PowerTwoRangeStmt(ExtendedProofStmt):
 class GenericRangeStmtMaker:
     """
     Auxiliary builder class for generic range proofs.
+
     .. math::
 
-        PK { (r, x): x G + r H & a <= x < b }
+        PK \{ (r, x): x G + r H \land a \leq x < b \}
 
     See "`Efficient Protocols for Set Membership and Range Proofs`_" by Camenisch
     et al., 2008.
-
-    .. _`Efficient Protocols for Set Membership and Range Proofs`:
-        https://infoscience.epfl.ch/record/128718/files/CCS08.pdf
 
     In practice, use the :py:obj:`zksk.primitives.rangeproof.RangeStmt` object directly:
 
@@ -168,6 +166,9 @@ class GenericRangeStmtMaker:
     True
 
     See :py:meth:`GenericRangeStmtMaker.__call__` for the construction signature.
+
+    .. `Efficient Protocols for Set Membership and Range Proofs`:
+        https://infoscience.epfl.ch/record/128718/files/CCS08.pdf
 
     """
 
@@ -223,13 +224,18 @@ class GenericRangeStmtMaker:
 class GenericRangeOnlyStmtMaker:
     """
     Auxiliary builder class for generic range proofs.
+
     .. math::
-        PK { (x): a <= x < b }
+        PK \{ (x): a \leq x < b \}
+
     See "`Efficient Protocols for Set Membership and Range Proofs`_" by Camenisch
     et al., 2008.
+
     .. _`Efficient Protocols for Set Membership and Range Proofs`:
         https://infoscience.epfl.ch/record/128718/files/CCS08.pdf
+
     In practice, use the :py:obj:`zksk.primitives.rangeproof.RangeStmt` object directly:
+
     >>> x = Secret(value=3)
     >>> lo = 0
     >>> hi = 5
@@ -289,4 +295,3 @@ class GenericRangeOnlyStmtMaker:
 # TODO: Make a regular class.
 RangeStmt = GenericRangeStmtMaker()
 RangeOnlyStmt = GenericRangeOnlyStmtMaker()
-

--- a/zksk/primitives/rangeproof.py
+++ b/zksk/primitives/rangeproof.py
@@ -233,7 +233,7 @@ class GenericRangeOnlyStmtMaker:
     >>> x = Secret(value=3)
     >>> lo = 0
     >>> hi = 5
-    >>> stmt = RangeStmt(lo, hi, x)
+    >>> stmt = RangeOnlyStmt(lo, hi, x)
     >>> nizk = stmt.prove()
     >>> stmt.verify(nizk)
     True

--- a/zksk/primitives/rangeproof.py
+++ b/zksk/primitives/rangeproof.py
@@ -264,8 +264,6 @@ class GenericRangeOnlyStmtMaker:
         if x is not None:
             x1.value = x.value - a
             x2.value = x.value - a + offset
-            print(x.value, a, offset)
-            print(x1.value, x2.value)
         com_stmt = DLRep(com, x * g + r * h)
         p1 = PowerTwoRangeStmt(
             com=com_shifted1,

--- a/zksk/primitives/rangeproof.py
+++ b/zksk/primitives/rangeproof.py
@@ -237,6 +237,7 @@ class GenericRangeOnlyStmtMaker:
     >>> nizk = stmt.prove()
     >>> stmt.verify(nizk)
     True
+
     See :py:meth:`GenericRangeStmtMaker.__call__` for the construction signature.
     """
 

--- a/zksk/primitives/rangeproof.py
+++ b/zksk/primitives/rangeproof.py
@@ -22,11 +22,13 @@ from zksk.composition import AndProofStmt
 
 def decompose_into_n_bits(value, n):
     """Array of bits, least significant bit first"""
-    base = [1 if value.is_bit_set(b) else 0 for b in range(value.num_bits())]
+    if value < 0:
+        raise Exception("Can't represent negative values")
+    base = [1 if value.is_bit_set(b) else 0 for b in range(value.num_bits() - 1, -1, -1)]
     extra_bits = n - len(base)
     if extra_bits < 0:
         raise Exception("Not enough bits to represent value")
-    return base + [0] * extra_bits
+    return [0] * extra_bits + base
 
 
 def next_exp_of_power_of_two(value):
@@ -134,17 +136,15 @@ class PowerTwoRangeStmt(ExtendedProofStmt):
         for c in precommitment["Cs"]:
             combined += power * c
             power *= 2
-
         return combined == self.com + rand * self.h
 
 
 class GenericRangeStmtMaker:
     """
     Auxiliary builder class for generic range proofs.
-
     .. math::
 
-        PK \{ (r, x): x G + r H \land a \leq x < b \}
+        PK { (r, x): x G + r H & a <= x < b }
 
     See "`Efficient Protocols for Set Membership and Range Proofs`_" by Camenisch
     et al., 2008.
@@ -183,7 +183,6 @@ class GenericRangeStmtMaker:
             b: Upper limit :math:`b`
             x: Value for which we construct a range proof
             randomizer: Randomizer of the commitment :math:`r`
-
         """
         a = ensure_bn(a)
         b = ensure_bn(b)
@@ -196,7 +195,7 @@ class GenericRangeStmtMaker:
         x2 = Secret()
         if x is not None:
             x1.value = x.value - a
-            x2.value = a - offset
+            x2.value = x.value - a + offset
 
         com_stmt = DLRep(com, x * g + r * h)
 
@@ -221,6 +220,74 @@ class GenericRangeStmtMaker:
         return com_stmt & p1 & p2
 
 
+class GenericRangeOnlyStmtMaker:
+    """
+    Auxiliary builder class for generic range proofs.
+    .. math::
+        PK { (x): a <= x < b }
+    See "`Efficient Protocols for Set Membership and Range Proofs`_" by Camenisch
+    et al., 2008.
+    .. _`Efficient Protocols for Set Membership and Range Proofs`:
+        https://infoscience.epfl.ch/record/128718/files/CCS08.pdf
+    In practice, use the :py:obj:`zksk.primitives.rangeproof.RangeStmt` object directly:
+    >>> x = Secret(value=3)
+    >>> lo = 0
+    >>> hi = 5
+    >>> stmt = RangeStmt(lo, hi, x)
+    >>> nizk = stmt.prove()
+    >>> stmt.verify(nizk)
+    True
+    See :py:meth:`GenericRangeStmtMaker.__call__` for the construction signature.
+    """
+
+    def __call__(self, a, b, x=None):
+        """
+        Get a conjunction of two range-power-of-two proofs.
+        Args:
+            a: Lower limit :math:`a`
+            b: Upper limit :math:`b`
+            x: Value for which we construct a range proof
+        """
+        group = EcGroup()
+        g = group.hash_to_point(b"g")
+        h = group.hash_to_point(b"h")
+        r = Secret(value=2)
+        com = (x * g + r * h).eval()
+        a = ensure_bn(a)
+        b = ensure_bn(b)
+        num_bits = (b - a - 1).num_bits()
+        offset = 2 ** num_bits - (b - a)
+        com_shifted1 = com - a * g
+        com_shifted2 = com_shifted1 - offset * g
+        x1 = Secret()
+        x2 = Secret()
+        if x is not None:
+            x1.value = x.value - a
+            x2.value = x.value - a + offset
+            print(x.value, a, offset)
+            print(x1.value, x2.value)
+        com_stmt = DLRep(com, x * g + r * h)
+        p1 = PowerTwoRangeStmt(
+            com=com_shifted1,
+            g=g,
+            h=h,
+            num_bits=num_bits,
+            x=x1,
+            randomizer=r,
+        )
+        p2 = PowerTwoRangeStmt(
+            com=com_shifted2,
+            g=g,
+            h=h,
+            num_bits=num_bits,
+            x=x2,
+            randomizer=r,
+        )
+
+        return com_stmt & p1 & p2
+
+
 # TODO: Make a regular class.
 RangeStmt = GenericRangeStmtMaker()
+RangeOnlyStmt = GenericRangeOnlyStmtMaker()
 


### PR DESCRIPTION
Wrong behavior of rangeproof if x has the same number of bits as (b - a).
In the following test, x \in [lo, hi] with x = 15, lo = 0, hi = 14 should fail.