### PR TITLE
Converting Range Proof offset exponentiation to Bn

### DIFF
--- a/tests/primitives/test_rangeproof.py
+++ b/tests/primitives/test_rangeproof.py
@@ -98,6 +98,20 @@ def test_range_stmt_non_interactive_start_at_zero(group):
     assert stmt.verify(tr)
 
 
+def test_range_stmt_non_interactive_big_range(group):
+    x = Secret(value=3)
+    randomizer = Secret(value=group.order().random())
+
+    g, h = make_generators(2, group)
+    lo = 0
+    hi = Bn(2) ** 65
+
+    com = x * g + randomizer * h
+    stmt = RangeStmt(com.eval(), g, h, lo, hi, x, randomizer)
+
+    tr = stmt.prove()
+    assert stmt.verify(tr)
+
 def test_range_stmt_non_interactive_start_at_nonzero(group):
     x = Secret(value=14)
     randomizer = Secret(value=group.order().random())
@@ -162,6 +176,14 @@ def test_range_proof_outside():
         nizk = stmt.prove()
         stmt.verify(nizk)
 
+
+def test_range_proof_big_range():
+    x = Secret(value=7)
+    lo = 0
+    hi = Bn(2) ** 65
+    stmt = RangeOnlyStmt(lo, hi, x)
+    nizk = stmt.prove()
+    assert stmt.verify(nizk) == True
 
 def test_range_proof_outside_range_above():
     x = Secret(value=7)

--- a/zksk/primitives/rangeproof.py
+++ b/zksk/primitives/rangeproof.py
@@ -214,7 +214,7 @@ class GenericRangeStmtMaker:
         a = ensure_bn(a)
         b = ensure_bn(b)
         num_bits = (b - a - 1).num_bits()
-        offset = 2 ** num_bits - (b - a)
+        offset = Bn(2) ** num_bits - (b - a)
 
         com_shifted1 = com - a * g
         com_shifted2 = com_shifted1 + offset * g
@@ -285,7 +285,7 @@ class GenericRangeOnlyStmtMaker:
         a = ensure_bn(a)
         b = ensure_bn(b)
         num_bits = (b - a - 1).num_bits()
-        offset = 2 ** num_bits - (b - a)
+        offset = Bn(2) ** num_bits - (b - a)
         com_shifted1 = com - a * g
         com_shifted2 = com_shifted1 + offset * g
 


### PR DESCRIPTION
Range proofs with a range greater than 32 bits failed because the constructor `petlib.bn.Bn()` does not support arguments greater than 32 bits.

Fixed by converting the base to a `petlib.bn.Bn` before exponentiation.
Added test cases to verify the bugfix.
